### PR TITLE
Fixed to accommodate latest site changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## **DISCLAIMER: This project is still in its early stages and may be prone to breaking changes. Use at your own risk.**
 
-Scrape Fakku metadata and build your own local Fakku manga library with ComicRack (or Ubooquity).
+Scrape Fakku metadata and build your own local FAKKU manga library with ComicRack, Komga, Ubooquity, any other CMS that supports `ComicInfo.xml` metadata.
 Currently supports scraping directly from `Fakku.net`, with failover to `panda.chaika.moe`.
 
 `Set-FakkuMetadata` will write a `ComicInfo.xml` metadata file directly into your manga archive,
@@ -48,7 +48,7 @@ supporting filetypes: .zip, .cbz, .rar, .cbr, .7z, and .cb7.
 ### Prerequisites
 
 - [PowerShell 5.0 or higher (6.0+ recommended)](<(https://github.com/PowerShell/PowerShell)>)
-- ComicRack, Ubooquity, or any other CMS that supports `ComicInfo.xml` metadata
+- ComicRack, Komga, Ubooquity, or any other CMS that supports `ComicInfo.xml` metadata
 
 #### Accepted archive filenames
 
@@ -62,11 +62,11 @@ Manga Title.ext
 
 ### Installing
 
-[Clone the repository](https://github.com/jvlflame/Fakku-Library/archive/master.zip) and extract the
+[Clone the repository](https://github.com/jvlflame/FkuLibrary/archive/master.zip) and extract the
 files to a directory of your choice.
 
-[Download the chromedriver](https://chromedriver.chromium.org/downloads) version that matches your version of chrome as well as the [Selenium WebDriver for C#](https://goo.gl/uJJ5Sc). Extract `chromedriver.exe` and `WebDriver.dll` to a writable path (by default, it tries `C:\Selenium`).
-> Note: The `WebDriver.dll` file is found inside `\selenium-dotnet-3.14.0.zip\dist\Selenium.WebDriver.3.14.0.nupkg\lib\net45\`. The .nupkg file can be renamed to .zip for easier access. If the chromedriver.exe isn't working as expected, ensure the version matches with your Chrome browser. If they're matching and it still doesn't work, try downgrading your chromedriver.exe version or updating your Chrome.
+[Download the chromedriver](https://chromedriver.chromium.org/downloads) version that matches your version of chrome as well as the [Selenium WebDriver for C#](https://goo.gl/uJJ5Sc). Extract `chromedriver.exe` and `WebDriver.dll` to a readable/writable path (by default, it looks at `C:\Selenium`).
+> Note: The `WebDriver.dll` file is packaged inside `\selenium-dotnet-3.14.0.zip\dist\Selenium.WebDriver.3.14.0.nupkg\lib\net45\`. The .nupkg file can be treated like a .zip. If ChromeDriver isn't working as expected, ensure the version matches with your Chrome browser. If they match and it still doesn't work, try downgrading the `chromedriver.exe` version or updating Chrome.
 
 #### Import the module
 
@@ -107,3 +107,8 @@ Set-FakkuMetadata -FilePath "C:\path\to\file\file.cbz"
 Set-FakkuMetadata -Remote -FilePath "C:\path\to\file\file.cbz"
 ```
 > Note: Use this to circumvent chromedriver opening a new window everytime when setting metadata to individual archives. Make sure to open Chrome with the --remote-debugging-port argument (tries --remote-debugging-port=5656 by default) and login to FAKKU beforehand.
+
+#### Get example metadata from a Fakku link
+```
+Get-FakkuMetadata https://www.fakku.net/hentai/Bare-Girl-english
+```

--- a/functions/Get-FakkuMetadata.ps1
+++ b/functions/Get-FakkuMetadata.ps1
@@ -5,7 +5,15 @@ function Get-FakkuMetadata {
         [String]$DoujinName,
 
         [Parameter(Mandatory = $false, Position = 0, ParameterSetName = 'Url')]
-        [String]$Url
+        [String]$Url,
+
+        # Sets path to chromedriver.exe and WebDriver.dll
+        [Parameter(Mandatory = $false)]
+        [System.IO.FileInfo]$WebDriverPath = "C:\Selenium",
+
+        # To circumvent chromedriver opening a new window every time when individually setting metadata. Open Chrome and login to FAKKU beforehand with the --remote-debugging-port argument (--remote-debugging-port=5656 by default)
+        [Parameter(Mandatory = $false)]
+        [Switch]$Remote
     )
 
     Switch ($PSCmdlet.ParameterSetName) {
@@ -13,7 +21,7 @@ function Get-FakkuMetadata {
             try {
                 $fakkuUrl = Get-FakkuURL -DoujinName $DoujinName
                 $fakkuData = Invoke-WebRequest $fakkuUrl -Method Get -Verbose:$false
-                $xml = Get-MetadataXML -WebRequest $fakkuData -Scraper Fakku
+                $xml = Get-MetadataXML -WebRequest $fakkuData -Scraper Fakku -URL $fakkuUrl
             } catch {
                 try {
                     $pandaChaikaUrl = Get-PandaChaikaURL -DoujinName $DoujinName
@@ -32,7 +40,7 @@ function Get-FakkuMetadata {
             try {
                 if ($Url -match 'fakku') {
                     $fakkuData = Invoke-WebRequest $Url -Method Get -Verbose:$false
-                    $xml = Get-MetadataXML -WebRequest $fakkuData -Scraper Fakku
+                    $xml = Get-MetadataXML -WebRequest $fakkuData -Scraper Fakku -URL $Url
                 } elseif ($Url -match 'panda.chaika') {
                     $pandaChaikaData = Invoke-WebRequest $Url -Method Get -Verbose:$false
                     $xml = Get-MetadataXML -Webrequest $pandaChaikaData -Scraper PandaChaika
@@ -40,10 +48,57 @@ function Get-FakkuMetadata {
                     Write-Warning "Url $Url is not a valid fakku or panda.chaika url"
                 }
             } catch {
-                Write-Warning "Error occurred while scraping $Url : $PSItem"
+                try {      
+                        # Test for and adds web driver directory to PATH
+                        if (Test-Path -Path $WebDriverPath) {
+                                if (($env:Path -split ';') -notcontains $WebDriverPath) {
+                                        $env:Path += ";$WebDriverPath"
+                                }
+                            
+                                if (-Not (Test-Path -Path (Join-Path -Path $WebDriverPath -ChildPath "chromedriver.exe"))) {
+                                        Write-Warning "chromedriver.exe does not exist. Download the version matching your browser version and extract to your web driver path - https://chromedriver.chromium.org/downloads"
+                                }
+                            
+                                if (-Not (Test-Path -Path (Join-Path -Path $WebDriverPath -ChildPath "WebDriver.dll"))) {
+                                        Write-Warning "WebDriver.dll does not exist. Download and extract WebDriver.dll from inside \selenium-dotnet-3.14.0.zip\dist\Selenium.WebDriver.3.14.0.nupkg\lib\net45\ to your web driver path - https://goo.gl/uJJ5Sc"
+                                }
+                        
+                        } else {
+                                Write-Warning "Web driver directory does not exist. Please set it using -WebDriverPath (C:\Selenium by default)"
+                        }
+
+                        # Opens a new window if it doesn't detect one open.
+                        if ([string]::IsNullOrEmpty($ChromeDriver.WindowHandles)) {
+                        $DllPath = Join-Path -Path $WebDriverPath -ChildPath "WebDriver.dll"
+                                Write-Host "Starting browser..."
+                                Import-Module $DllPath
+                                $Service = [OpenQA.Selenium.Chrome.ChromeDriverService]::CreateDefaultService($WebDriverPath)
+                                $Service.SuppressInitialDiagnosticInformation = $true
+                                $Service.HideCommandPromptWindow = $true
+                                if ($Remote) {
+                                        $ChromeOptions = New-Object OpenQA.Selenium.Chrome.ChromeOptions
+                                        $ChromeOptions.debuggerAddress = "127.0.0.1:5656"
+                                        $ChromeDriver = [OpenQA.Selenium.Chrome.ChromeDriver]::new($Service, $ChromeOptions)
+                                } else {
+                                        $ChromeDriver = [OpenQA.Selenium.Chrome.ChromeDriver]::new($Service)
+                                        $ChromeDriver.Navigate().GoToURL("https://fakku.net/login")
+                                        Write-Host -NoNewLine 'Please log into FAKKU then press any key to continue...'
+                                        $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+                                }  
+                        }
+                        $ChromeDriver.Navigate().GoToURL($Url)
+                        $xml = Get-MetadataXML -WebRequest $ChromeDriver.PageSource -Scraper Fakku -URL $Url
+                } 
+                catch {
+                    Write-Warning "Error occurred while scraping $Url : $PSItem"
+                }
             }
 
             Write-Output $xml
+
+            if ($ChromeDriver) {
+                $ChromeDriver.Quit()
+            }
         }
     }
 }

--- a/functions/Set-FakkuMetadata.ps1
+++ b/functions/Set-FakkuMetadata.ps1
@@ -20,7 +20,7 @@ function Set-FakkuMetadata {
                 [Parameter(Mandatory = $false)]
                 [System.IO.FileInfo]$WebDriverPath = "C:\Selenium",
 
-                # Use this to circumvent chromedriver opening a new window everytime when individually setting metadata. Make sure to open Chrome and login to FAKKU beforehand with the --remote-debugging-port argument (--remote-debugging-port=5656 by default)
+                # To circumvent chromedriver opening a new window every time when individually setting metadata. Open Chrome and login to FAKKU beforehand with the --remote-debugging-port argument (--remote-debugging-port=5656 by default)
                 [Parameter(Mandatory = $false)]
                 [Switch]$Remote
         )
@@ -105,7 +105,7 @@ function Set-FakkuMetadata {
 
                 # Try to get credentials before falling back on panda.chaika.moe
                 catch {
-                        try{
+                        try {
                                 if (!$UriLocation) {
                                         Write-Warning "Attempting to use browser..."
                                         $FakkuUrl = Get-FakkuURL -DoujinName $File.BaseName
@@ -116,18 +116,13 @@ function Set-FakkuMetadata {
                                         if (($env:Path -split ';') -notcontains $WebDriverPath) {
                                                 $env:Path += ";$WebDriverPath"
                                         }
-                                    
                                         if (-Not (Test-Path -Path (Join-Path -Path $WebDriverPath -ChildPath "chromedriver.exe"))) {
                                                 Write-Warning "chromedriver.exe does not exist. Download the version matching your browser version and extract to your web driver path - https://chromedriver.chromium.org/downloads"
                                         }
-                                    
                                         if (-Not (Test-Path -Path (Join-Path -Path $WebDriverPath -ChildPath "WebDriver.dll"))) {
                                                 Write-Warning "WebDriver.dll does not exist. Download and extract WebDriver.dll from inside \selenium-dotnet-3.14.0.zip\dist\Selenium.WebDriver.3.14.0.nupkg\lib\net45\ to your web driver path - https://goo.gl/uJJ5Sc"
                                         }
-                                
-                                } 
-                                
-                                else {
+                                } else {
                                         Write-Warning "Web driver directory does not exist. Please set it using -WebDriverPath (C:\Selenium by default)"
                                 }
 
@@ -143,16 +138,13 @@ function Set-FakkuMetadata {
                                                 $ChromeOptions = New-Object OpenQA.Selenium.Chrome.ChromeOptions
                                                 $ChromeOptions.debuggerAddress = "127.0.0.1:5656"
                                                 $ChromeDriver = [OpenQA.Selenium.Chrome.ChromeDriver]::new($Service, $ChromeOptions)
-                                        } 
-                                        
-                                        else {
+                                        } else {
                                                 $ChromeDriver = [OpenQA.Selenium.Chrome.ChromeDriver]::new($Service)
                                                 $ChromeDriver.Navigate().GoToURL("https://fakku.net/login")
                                                 Write-Host -NoNewLine 'Please log into FAKKU then press any key to continue...'
                                                 $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
                                         }  
                                 }
-                                
                                 $ChromeDriver.Navigate().GoToURL($FakkuUrl)
                                 $xml = $null
                                 $xml = Get-MetadataXML -WebRequest $ChromeDriver.PageSource -Scraper Fakku -URL $FakkuUrl
@@ -160,7 +152,6 @@ function Set-FakkuMetadata {
                                 Write-FakkuLog -Log:$Log -LogPath $LogPath -Source "Fakku"
                                 Write-Verbose "Set $FilePath with $FakkuUrl"
                                 Write-Debug "Set $File using Fakku"
-
                         }
 
                         # If the Fakku URL returns an error, fallback to panda.chaika.moe

--- a/internal/Get-FakkuArtist.ps1
+++ b/internal/Get-FakkuArtist.ps1
@@ -5,11 +5,11 @@ function Get-FakkuArtist {
                 [String]$WebRequest
         )
 
-        $Artist = (((($WebRequest -split '<div class=\"row-right\"><a href=\"\/artists\/(.*?)\">')[2])`
-                                -split '<\/a><\/div>')[0]).Trim()
+        # Modified to account for multiple artists
+        $rawArtist = (((($WebRequest -split '<div class=\"(.*?)\">Artist<\/div>')[2])`
+            -split '<\/div>')[0]).Trim()
 
-        $Artist = $Artist -replace '<[^>]*>', ''`
-                -replace '[\r\n\t\f\v]', ''
+        $Artist = (($rawArtist | Select-String -Pattern '<a[^>]* href="[^>]*>([^<]*)' -AllMatches).Matches | ForEach-Object { ($_.Groups[1].Value).Trim() } | Where-Object {$_ -ne ""}) -join ", "
 
         Write-Output $Artist
 }

--- a/internal/Get-FakkuGenres.ps1
+++ b/internal/Get-FakkuGenres.ps1
@@ -5,11 +5,12 @@ function Get-FakkuGenres {
                 [String]$WebRequest
         )
 
-        $rawGenres = (((($WebRequest -split '<div class="row-right tags">')[1])`
-                                -split 'class="js-suggest-tag"')[0])
+        $rawGenres = (((($WebRequest -split '<div class="table-cell w-full align-top text-left -mb-2">')[1])`
+                -split 'class="inline-block cursor-pointer bg-gray-100 leading-loose rounded py-1 px-3 mr-2 dark:bg-gray-800 text-gray-900 dark:text-gray-400 js-suggest-tag"')[0])`
+                -replace "`n","" -replace "`r",""
 
         try {
-                $genres = ($rawGenres | Select-String -Pattern '(.*)<\/a>' -AllMatches).Matches | ForEach-Object { ($_.Groups[1].Value).Trim() }
+                $Genres = ($rawGenres | Select-String -Pattern '>([^<]*)<' -AllMatches).Matches | ForEach-Object { ($_.Groups[1].Value).Trim() } | Where-Object {$_ -ne ""}
         } catch {
                 # Do nothing
         }

--- a/internal/Get-FakkuParody.ps1
+++ b/internal/Get-FakkuParody.ps1
@@ -5,12 +5,11 @@ function Get-FakkuParody {
                 [String]$WebRequest
         )
 
-        $Parody = (((((($WebRequest -split '<div class=\"row-left\">Parody<\/div>')[1])`
-                                                -split '<div class=\"row-right\"><a href=\"\/series\/(.*?)\">')[2])`
-                                -split '</a></div>')[0]).Trim()
-
-        $Parody = $Parody -replace '<[^>]*>', ''`
-                -replace '[\r\n\t\f\v]', ''
+        # In the rare case there's multiple Parody attributions, it will only take the first
+        $Parody = (((($WebRequest -split '<a href=\"\/series\/(.*?)\">')[2])`
+            -split '<\/a>')[0]).Trim()`
+            -replace ',', ''`
+            -replace '&', '&amp;'
 
         Write-Output $Parody
 }

--- a/internal/Get-FakkuPublisher.ps1
+++ b/internal/Get-FakkuPublisher.ps1
@@ -6,8 +6,8 @@ function Get-FakkuPublisher {
         )
 
         #$TextInfo = (Get-Culture).TextInfo
-        $Publisher = (((($WebRequest -split '<div class=\"row-right\"><a href=\"\/publishers\/(.*?)\">')[2])`
-                                -split '<\/a><\/div>')[0]).Trim()
+        $Publisher = (((($WebRequest -split '<a href=\"\/publishers\/(.*?)\">')[2])`
+                -split '<\/a><\/div>')[0]).Trim()
 
         #$publisher = $TextInfo.ToTitleCase($rawPublisher)
         Write-Output $Publisher

--- a/internal/Get-FakkuSeries.ps1
+++ b/internal/Get-FakkuSeries.ps1
@@ -5,12 +5,15 @@ function Get-FakkuSeries {
                 [String]$WebRequest
         )
 
-        #$TextInfo = (Get-Culture).TextInfo
-        $Series = (((($WebRequest -split '<div class=\"row-right\"><a href=\"\/magazines\/(.*?)\">')[2])`
-                                -split '<\/a><\/div>')[0]).Trim()
+        # (Removed title case in favor of official stylization)
+        #$TextInfo = (Get-Culture).TextInfo 
+        $Series = (((($WebRequest -split '<a href=\"\/magazines\/(.*?)\">')[2])`
+                -split '<\/a><\/div>')[0]).Trim()
+
+        # Will use event instead if there is no magazine
 	if ([string]::IsNullOrEmpty($Series)) {
-		$Series = (((($WebRequest -split '<div class=\"row-right\"><a href=\"\/events\/(.*?)\">')[2])`
-                                	-split '<\/a><\/div>')[0]).Trim()
+		$Series = (((($WebRequest -split '<a href=\"\/events\/(.*?)\">')[2])`
+                        -split '<\/a><\/div>')[0]).Trim()
 	}
         
         $Series = $Series -replace '<[^>]*>', ''`

--- a/internal/Get-FakkuSummary.ps1
+++ b/internal/Get-FakkuSummary.ps1
@@ -5,18 +5,19 @@ function Get-FakkuSummary {
                 [String]$WebRequest
         )
 
-        $rawSummary = ((((($WebRequest -split '<div class="row-left">Description<\/div>')[1])`
-                                        -split '<div class="row-right">')[1]`
-                                -split '<\/div>')[0]).Trim()
+        # Will try to detect where line breaks should be present and insert them (letter/number directly following punctuation)
+        $Summary = (((($WebRequest -split '<meta name="description" content=" ')[1])`
+                -split '">')[0]).Trim()`
+                -replace '(\.|\?|\!)([a-zA-Z0-9])', '$1`n`n$2'`
+                -replace '&', '&amp;'
 
-        # Removes the <br><br> string which appears in the raw HTML when the description on Fakku has line breaks
-        # Added filtering for other tags and changed line break to insert new lines
-        $summary = $rawSummary -replace '<br>', "`n"`
+        # Removing as new site layout requires getting description from the header
+        <#$Summary = $rawSummary -replace '<br>', "`n"`
                 -replace '<br />', "`n"`
                 -replace '<br/>', "`n"`
                 -replace '</p>', "`n"`
                 -replace'<a[^>]*>(.*?)<\/a>', '$1'`
                 -replace '<[^>]*>', ''`
-                -replace '&', '&amp;'
-        Write-Output $summary
+                -replace '&', '&amp;'#>
+        Write-Output $Summary
 }

--- a/internal/Get-FakkuTitle.ps1
+++ b/internal/Get-FakkuTitle.ps1
@@ -5,10 +5,9 @@ function Get-FakkuTitle {
                 [String]$WebRequest
         )
 
-        $title = (((((($WebRequest -split '<div class=\"content-name\">')[1])`
-                                                -split '<h1>')[1])`
-                                -split '<\/h1>')[0]).Trim()
-        $title = $title -replace '&', '&amp;'
+        # Site layout change makes it easier to grab title from <title> tag
+        $Title = (($WebRequest -split '<title>(.*?) Hentai by .*? - FAKKU<\/title>')[1]).Trim()`
+                -replace '&', '&amp;'
 
-        Write-Output $title
+        Write-Output $Title
 }

--- a/internal/Get-FakkuUrl.ps1
+++ b/internal/Get-FakkuUrl.ps1
@@ -5,7 +5,7 @@ function Get-FakkuURL {
                 [String]$DoujinName
         )
         # Added other special character exceptions
-        #It looks like some links convert apostrophes (') to 'bgb' while some don't. Can't really be bothered to write an elegant solution that checks both link possibilites
+        # It looks like some links convert apostrophes (') to 'bgb' while some don't. Can't really be bothered to write an elegant solution that checks both link possibilites
         $DoujinName = $DoujinName -replace '★', 'bzb' `
                 -replace '☆', 'byb' `
                 -replace '♪', 'bvb' `
@@ -15,10 +15,11 @@ function Get-FakkuURL {
         # Gets the filename and converts it to a parseable Fakku web URL
         # The filename must match exactly what is presented by Fakku or scrape will fail
         # Match and clean "[Artist] FileName (Comic XXX).ext"
+        # Also inadvertently removes titles in brackets, but that's a rare occurence
         if ($DoujinName -match '^\[(.*?)\]') {
                 $CleanFileName = (((((($DoujinName -split "]")[1])`
-                                                        -split "\(")[0]).Trim())`
-                                -replace '[^-a-z0-9 ]+', '')`
+                        -split "\(")[0]).Trim())`
+                        -replace '[^-a-z0-9 ]+', '')`
                         -replace ' ', '-'`
                         -replace '---', '-'`
                         -replace '--', '-'
@@ -27,7 +28,7 @@ function Get-FakkuURL {
         # Match and clean "FileName (Comic XXX).ext"
         elseif ($DoujinName -match '^\[(.*?)\]') {
                 $CleanFileName = (((($DoujinName -split "\(")[0]).Trim())`
-                                -replace '[^-a-z0-9 ]+', '')`
+                        -replace '[^-a-z0-9 ]+', '')`
                         -replace ' ', '-'`
                         -replace '---', '-'`
                         -replace '--', '-'

--- a/internal/Get-MetadataXML.ps1
+++ b/internal/Get-MetadataXML.ps1
@@ -49,7 +49,7 @@ function Get-MetadataXML {
                 $Year = $Month = ""
         }
 
-        # Uses SeriesGroup instead of Series as I think Magazines/Events are less a discrete series and more a grouping of series. This also improves how Komga sorts.
+        # Changed to use SeriesGroup instead of Series for Magazines/Events as they're more a grouping of series than actual series. This greatly improves how Komga sorts.
         $Content = @"
 <?xml version="1.0"?>
 <ComicInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">


### PR DESCRIPTION
Fakku got a site overhaul a while ago, but I didn't get around to fixing this until now. As far as I'm aware, everything works properly again, albeit slightly differently since the HTML changed. I also updated the `Get-FakkuMetadata.ps1` to work properly with hidden content since I skipped over that previously. My only real concern with the code is how it grabs tags as it's a bit janky. While it worked correctly with my tests, it could probably be improved. Hope you have time to go over this 👍 