### PR TITLE
Improve regex/Fix newline not inserting correctly in summary

### DIFF
--- a/internal/Get-FakkuArtist.ps1
+++ b/internal/Get-FakkuArtist.ps1
@@ -6,10 +6,10 @@ function Get-FakkuArtist {
         )
 
         # Modified to account for multiple artists
-        $rawArtist = (((($WebRequest -split '<div class=\"(.*?)\">Artist<\/div>')[2])`
+        $rawArtist = (((($WebRequest -split '<div.*>Artist<\/div>')[1])`
             -split '<\/div>')[0]).Trim()
 
-        $Artist = (($rawArtist | Select-String -Pattern '<a[^>]* href="[^>]*>([^<]*)' -AllMatches).Matches | ForEach-Object { ($_.Groups[1].Value).Trim() } | Where-Object {$_ -ne ""}) -join ", "
+        $Artist = (($rawArtist -replace "`n","" -replace "`r","" | Select-String -Pattern '<a.*?artists.*?>(.*?(?=<))' -AllMatches).Matches | ForEach-Object { ($_.Groups[1].Value).Trim() }) -join ", "
 
         Write-Output $Artist
 }

--- a/internal/Get-FakkuArtist.ps1
+++ b/internal/Get-FakkuArtist.ps1
@@ -6,7 +6,7 @@ function Get-FakkuArtist {
         )
 
         # Modified to account for multiple artists
-        $rawArtist = (((($WebRequest -split '<div.*>Artist<\/div>')[1])`
+        $rawArtist = (((($WebRequest -split '<div.*>[Aa]rtist<\/div>')[1])`
             -split '<\/div>')[0]).Trim()
 
         $Artist = (($rawArtist -replace "`n","" -replace "`r","" | Select-String -Pattern '<a.*?artists.*?>(.*?(?=<))' -AllMatches).Matches | ForEach-Object { ($_.Groups[1].Value).Trim() }) -join ", "

--- a/internal/Get-FakkuGenres.ps1
+++ b/internal/Get-FakkuGenres.ps1
@@ -5,17 +5,8 @@ function Get-FakkuGenres {
                 [String]$WebRequest
         )
 
-        $rawGenres = (((($WebRequest -split '<div class="table-cell w-full align-top text-left -mb-2">')[1])`
-                -split 'class="inline-block cursor-pointer bg-gray-100 leading-loose rounded py-1 px-3 mr-2 dark:bg-gray-800 text-gray-900 dark:text-gray-400 js-suggest-tag"')[0])`
-                -replace "`n","" -replace "`r",""
+        # Purposefully chose to omit the "Unlimited" tag
+        $Genres = (($WebRequest -replace "`n","" -replace "`r","" | Select-String -Pattern '<a href="\/tags\/.*?>(.*?(?=<))' -AllMatches).Matches | ForEach-Object { ($_.Groups[1].Value).Trim() }) -join ", "
 
-        try {
-                $Genres = ($rawGenres | Select-String -Pattern '>([^<]*)<' -AllMatches).Matches | ForEach-Object { ($_.Groups[1].Value).Trim() } | Where-Object {$_ -ne ""}
-        } catch {
-                # Do nothing
-        }
-
-        # Formats the genres as a comma-delimited string "Genre1, Genre2, etc." which is accepted by ComicInfo.xml format
-        $genreString = $genres[0..($Genres.Length - 1)] -join ", "
-        Write-Output $genreString
+        Write-Output $Genres
 }

--- a/internal/Get-FakkuParody.ps1
+++ b/internal/Get-FakkuParody.ps1
@@ -6,7 +6,7 @@ function Get-FakkuParody {
         )
 
         # In the rare case there's multiple Parody attributions, it will only take the first
-        $Parody = (((($WebRequest -split '<a href=\"\/series\/(.*?)\">')[2])`
+        $Parody = (((($WebRequest -split '<a.*series.*?>')[1])`
             -split '<\/a>')[0]).Trim()`
             -replace ',', ''`
             -replace '&', '&amp;'

--- a/internal/Get-FakkuPublisher.ps1
+++ b/internal/Get-FakkuPublisher.ps1
@@ -5,10 +5,8 @@ function Get-FakkuPublisher {
                 [String]$WebRequest
         )
 
-        #$TextInfo = (Get-Culture).TextInfo
-        $Publisher = (((($WebRequest -split '<a href=\"\/publishers\/(.*?)\">')[2])`
-                -split '<\/a><\/div>')[0]).Trim()
+        $Publisher = (((($WebRequest -split '<a.*publishers.*?>')[1])`
+                -split '<\/a>')[0]).Trim()
 
-        #$publisher = $TextInfo.ToTitleCase($rawPublisher)
         Write-Output $Publisher
 }

--- a/internal/Get-FakkuSeries.ps1
+++ b/internal/Get-FakkuSeries.ps1
@@ -5,20 +5,14 @@ function Get-FakkuSeries {
                 [String]$WebRequest
         )
 
-        # (Removed title case in favor of official stylization)
-        #$TextInfo = (Get-Culture).TextInfo 
-        $Series = (((($WebRequest -split '<a href=\"\/magazines\/(.*?)\">')[2])`
-                -split '<\/a><\/div>')[0]).Trim()
+        $Series = (((($WebRequest -split '<a.*magazines.*?>')[1])`
+                -split '<\/a>')[0]).Trim()
 
         # Will use event instead if there is no magazine
 	if ([string]::IsNullOrEmpty($Series)) {
-		$Series = (((($WebRequest -split '<a href=\"\/events\/(.*?)\">')[2])`
-                        -split '<\/a><\/div>')[0]).Trim()
+		$Series = (((($WebRequest -split '<a.*events.*?>')[1])`
+                        -split '<\/a>')[0]).Trim()
 	}
-        
-        $Series = $Series -replace '<[^>]*>', ''`
-                -replace '[\r\n\t\f\v]', ''
 
-        #$Series = $TextInfo.ToTitleCase($rawSeries)
         Write-Output $Series
 }

--- a/internal/Get-FakkuSummary.ps1
+++ b/internal/Get-FakkuSummary.ps1
@@ -5,13 +5,13 @@ function Get-FakkuSummary {
                 [String]$WebRequest
         )
 
-        # Will try to detect where line breaks should be present and insert them (letter/number directly following punctuation)
-        $Summary = (((($WebRequest -split '<meta name="description" content=" ')[1])`
+        # Try to detect where line breaks should be and insert them (letter/number directly following punctuation)
+        $Summary = (((($WebRequest -split '<meta name="description" content="')[1])`
                 -split '">')[0]).Trim()`
-                -replace '(\.|\?|\!)([a-zA-Z0-9])', '$1`n`n$2'`
+                -replace '(\.|\?|\!)([a-zA-Z0-9])', ('$1'+"`n`n"+'$2')`
                 -replace '&', '&amp;'
 
-        # Removing as new site layout requires getting description from the header
+        # Removed since description is grabbed from header now
         <#$Summary = $rawSummary -replace '<br>', "`n"`
                 -replace '<br />', "`n"`
                 -replace '<br/>', "`n"`

--- a/internal/Get-FakkuTitle.ps1
+++ b/internal/Get-FakkuTitle.ps1
@@ -6,7 +6,7 @@ function Get-FakkuTitle {
         )
 
         # Site layout change makes it easier to grab title from <title> tag
-        $Title = (($WebRequest -split '<title>(.*?) Hentai by .*? - FAKKU<\/title>')[1]).Trim()`
+        $Title = (($WebRequest -split '<title>(.*?)[Hh]entai by.*<\/title>')[1]).Trim()`
                 -replace '&', '&amp;'
 
         Write-Output $Title

--- a/internal/Get-FakkuUrl.ps1
+++ b/internal/Get-FakkuUrl.ps1
@@ -6,7 +6,7 @@ function Get-FakkuURL {
         )
         # Added other special character exceptions
         # It looks like some links convert apostrophes (') to 'bgb' while some don't. Can't really be bothered to write an elegant solution that checks both link possibilites
-        $DoujinName = $DoujinName -replace '★', 'bzb' `
+        $DoujinName -replace '★', 'bzb' `
                 -replace '☆', 'byb' `
                 -replace '♪', 'bvb' `
                 -replace '↑', 'b' `
@@ -14,32 +14,26 @@ function Get-FakkuURL {
                 -replace '  ', ' '
         # Gets the filename and converts it to a parseable Fakku web URL
         # The filename must match exactly what is presented by Fakku or scrape will fail
-        # Match and clean "[Artist] FileName (Comic XXX).ext"
-        # Also inadvertently removes titles in brackets, but that's a rare occurence
-        if ($DoujinName -match '^\[(.*?)\]') {
-                $CleanFileName = (((((($DoujinName -split "]")[1])`
+        # Match and clean "[Artist] FileName (Comic XXX).ext" (This works incorrectly when titles have parentheses in them)
+        # Inadvertently removes titles in brackets, but that's a rare occurence
+        if ($DoujinName -match '^\[.*?\]') {
+                $CleanFileName = ((((($DoujinName -split "]")[1])`
                         -split "\(")[0]).Trim())`
-                        -replace '[^-a-z0-9 ]+', '')`
                         -replace ' ', '-'`
-                        -replace '---', '-'`
-                        -replace '--', '-'
+                        -replace '--{2,}', '-'
         }
 
         # Match and clean "FileName (Comic XXX).ext"
-        elseif ($DoujinName -match '^\[(.*?)\]') {
-                $CleanFileName = (((($DoujinName -split "\(")[0]).Trim())`
-                        -replace '[^-a-z0-9 ]+', '')`
+        elseif ($DoujinName -match '\(') {
+                $CleanFileName = ((($DoujinName -split "\(")[0]).Trim())`
                         -replace ' ', '-'`
-                        -replace '---', '-'`
-                        -replace '--', '-'
+                        -replace '--{2,}', '-'
 }
 
         # Match and clean "FileName.ext"
         elseif ($DoujinName -match '^[a-zA-Z0-9]') {
-                $CleanFileName = ($DoujinName -replace '[^-a-z0-9 ]+', '')`
-                        -replace ' ', '-'`
-                        -replace '---', '-'`
-                        -replace '--', '-'
+                $CleanFileName = $DoujinName -replace ' ', '-'`
+                        -replace '--{2,}', '-'
         }
 
         if ($CleanFileName.Substring($CleanFileName.Length - 1) -match "-") {

--- a/internal/Get-MetadataXML.ps1
+++ b/internal/Get-MetadataXML.ps1
@@ -39,7 +39,7 @@ function Get-MetadataXML {
                 $Month = "`n  <Month>$Month</Month>"
         } 
 
-        elseif ($series -match "\b\d{4}\b") {
+        elseif ($Series -match "\b\d{4}\b") {
                 $Year = $matches[0]
                 $Year = "`n  <Year>$Year</Year>"
                 $Month = ""


### PR DESCRIPTION
Sorry for another PR so soon, I probably should've just spent a bit more time polishing it. I fixed the janky regex of the genre scraping since it was bothering me with how bad it was lol. It should be a lot better now since it doesn't look for an arbitrary div. I also did a pass over the rest and improved them where I could. There's still a slight issue with how the scraper derives URLs from file names if there's brackets or parentheses in the title, but with how uncommon the latter is with the former being even more so, I figured it's not worth overcomplicating it. Hopefully if there's another change to their HTML, it will be more or less okay.