### PR TITLE
Batch archive tagging and various fixes

### DIFF
--- a/functions/Set-FakkuMetadata.ps1
+++ b/functions/Set-FakkuMetadata.ps1
@@ -102,32 +102,34 @@ function Set-FakkuMetadata {
                         }
                 }
 
-                # Ideally would restructure to not be in main loop sorry
-                if ($File -match "(?<ArchivePath>.+(?=$Separator))$Separator(?<ArchiveURL>https[^$Separator]+)$") {
-                        if (Test-Path -Path $Matches.ArchivePath -PathType Leaf) {
-                                $File = Get-Item $Matches.ArchivePath
-                                $Url = $Matches.ArchiveURL
-                                if ($Url -match 'fakku') {
-                                        $UriLocation = 'fakku'
-                                        $FakkuUrl = $Url
-                                } elseif ($Url -match 'panda.chaika') {
-                                        $UriLocation = 'panda.chaika'
-                                        $PandaChaikaUrl = $Url
+                # Ideally would restructure to not be in main loop sorry. Also kinda bad tbh lol
+                if ($InputFile) {
+                        if ($File -match "(?<ArchivePath>.+(?=$Separator))$Separator(?<ArchiveURL>https[^$Separator]+)$") {
+                                if (Test-Path -Path $Matches.ArchivePath -PathType Leaf) {
+                                        $File = Get-Item $Matches.ArchivePath
+                                        $Url = $Matches.ArchiveURL
+                                        if ($Url -match 'fakku') {
+                                                $UriLocation = 'fakku'
+                                                $FakkuUrl = $Url
+                                        } elseif ($Url -match 'panda.chaika') {
+                                                $UriLocation = 'panda.chaika'
+                                                $PandaChaikaUrl = $Url
+                                        } else {
+                                                Write-Warning "Url $Url is not a valid fakku or panda.chaika url"
+                                                return
+                                        }
                                 } else {
-                                        Write-Warning "Url $Url is not a valid fakku or panda.chaika url"
+                                        Write-Warning "$File is not a valid path"
                                         return
                                 }
+                                
                         } else {
-                                Write-Warning "$File is not a valid path"
-                                return
-                        }
-                        
-                } else {
-                        if (Test-Path -Path $File -PathType Leaf){
-                                $File = Get-Item $File
-                        } else {
-                                Write-Warning "$File is not a valid path"
-                                return
+                                if (Test-Path -Path $File -PathType Leaf){
+                                        $File = Get-Item $File
+                                } else {
+                                        Write-Warning "$File is not a valid path"
+                                        return
+                                }
                         }
                 }
 

--- a/internal/Get-FakkuParody.ps1
+++ b/internal/Get-FakkuParody.ps1
@@ -9,7 +9,7 @@ function Get-FakkuParody {
         $Parody = (((($WebRequest -split '<a.*series.*?>')[1])`
             -split '<\/a>')[0]).Trim()`
             -replace ',', ''`
-            -replace '&', '&amp;'
+            -replace '&(?!amp;)', '&amp;'
 
         Write-Output $Parody
 }

--- a/internal/Get-FakkuSummary.ps1
+++ b/internal/Get-FakkuSummary.ps1
@@ -5,10 +5,8 @@ function Get-FakkuSummary {
                 [String]$WebRequest
         )
 
-        # Try to detect where line breaks should be and insert them (letter/number directly following punctuation)
         $Summary = (((($WebRequest -split '<meta name="description" content="')[1])`
                 -split '">')[0]).Trim()`
-                -replace '(\.|\?|\!)([a-zA-Z0-9])', ('$1'+"`n`n"+'$2')`
                 -replace '&(?!amp;)', '&amp;'
 
         # Removed since description is grabbed from header now

--- a/internal/Get-FakkuSummary.ps1
+++ b/internal/Get-FakkuSummary.ps1
@@ -9,7 +9,7 @@ function Get-FakkuSummary {
         $Summary = (((($WebRequest -split '<meta name="description" content="')[1])`
                 -split '">')[0]).Trim()`
                 -replace '(\.|\?|\!)([a-zA-Z0-9])', ('$1'+"`n`n"+'$2')`
-                -replace '&', '&amp;'
+                -replace '&(?!amp;)', '&amp;'
 
         # Removed since description is grabbed from header now
         <#$Summary = $rawSummary -replace '<br>', "`n"`

--- a/internal/Get-FakkuTitle.ps1
+++ b/internal/Get-FakkuTitle.ps1
@@ -7,7 +7,7 @@ function Get-FakkuTitle {
 
         # Site layout change makes it easier to grab title from <title> tag
         $Title = (($WebRequest -split '<title>(.*?)[Hh]entai by.*<\/title>')[1]).Trim()`
-                -replace '&', '&amp;'
+                -replace '&(?!amp;)', '&amp;'
 
         Write-Output $Title
 }

--- a/internal/Get-FakkuUrl.ps1
+++ b/internal/Get-FakkuUrl.ps1
@@ -6,7 +6,7 @@ function Get-FakkuURL {
         )
         # Added other special character exceptions
         # It looks like some links convert apostrophes (') to 'bgb' while some don't. Can't really be bothered to write an elegant solution that checks both link possibilites
-        $DoujinName -replace '★', 'bzb' `
+        $DoujinName = $DoujinName -replace '★', 'bzb' `
                 -replace '☆', 'byb' `
                 -replace '♪', 'bvb' `
                 -replace '↑', 'b' `
@@ -19,21 +19,24 @@ function Get-FakkuURL {
         if ($DoujinName -match '^\[.*?\]') {
                 $CleanFileName = ((((($DoujinName -split "]")[1])`
                         -split "\(")[0]).Trim())`
+                        -replace '[^-a-z0-9 ]+', ''`
                         -replace ' ', '-'`
-                        -replace '--{2,}', '-'
+                        -replace '-{2,}', '-'
         }
 
         # Match and clean "FileName (Comic XXX).ext"
         elseif ($DoujinName -match '\(') {
                 $CleanFileName = ((($DoujinName -split "\(")[0]).Trim())`
+                        -replace '[^-a-z0-9 ]+', ''`
                         -replace ' ', '-'`
-                        -replace '--{2,}', '-'
+                        -replace '-{2,}', '-'
 }
 
         # Match and clean "FileName.ext"
         elseif ($DoujinName -match '^[a-zA-Z0-9]') {
                 $CleanFileName = $DoujinName -replace ' ', '-'`
-                        -replace '--{2,}', '-'
+                        -replace '[^-a-z0-9 ]+', ''`
+                        -replace '-{2,}', '-'
         }
 
         if ($CleanFileName.Substring($CleanFileName.Length - 1) -match "-") {


### PR DESCRIPTION
Last one, I promise lol. I wish I wasn't truly awful with regex. Fixed a few of my typos, namely one in `Get-FakkuUrl.ps1` that caused URL fetching to not work (whoops no idea how I missed that). Also fixed ampersand regex replacement since it wouldn't fully remove the tag as well as fixed the regex for removing extraneous dashes from Title → URL conversion. Lastly, added batch tagging via text file. Originally, I had just added it for myself since I found myself re-scraping my metadata to check for 1:1 accuracy, but figured may as well PR in case it was okay. The `-InputFile` parameter will check for a given text file line by line for archive paths. It will also optionally check for a URL proceeding the path separated by a ">" by default (e.g. `C:\path\to\file\file.cbz>https://www.fakku.net/hentai/hentai-name`). While re-scraping functionality that checks for pre-existing URLs within the `ComicInfo.xml` would be nicer, frankly I had used a hacky python script myself to read and grab the data since I'm horrid at powershell lol. Sorry for all the PRs again, I'm kind of just fixing my errors which is less than ideal. Hopefully (fingers crossed) I didn't miss anything this time!